### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "version": "0.0.1alpha",
   "author": "Angel 'Java' Lopez <webmaster@ajlopez.com> (http://www.ajlopez.com)",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/ajlopez/beljs.git"


### PR DESCRIPTION
Add license field to package.json
Prevents a warning that occurs when you `npm install`

package.json reference: https://docs.npmjs.com/files/package.json