### PR TITLE
Remove unused argument from execute call

### DIFF
--- a/test/execute.js
+++ b/test/execute.js
@@ -7,11 +7,10 @@ exports['execute function definition and apply it'] = function (test) {
 };
 
 exports['execute set from inner context'] = function (test) {
-    test.equal(bel.execute('(def setanswer (x) (set answer x)) (setanswer 42)', top), 42);
-    test.equal(top.get('answer'), 42);    
+    test.equal(bel.execute('(def setanswer (x) (set answer x)) (setanswer 42)'), 42);
+    test.equal(top.get('answer'), 42);
 };
 
 exports['execute function defined in another function'] = function (test) {
-    test.equal(bel.execute('(def defadd (x) (def add (y) (+ x y))) (defadd 2) (add 40)', top), 42);
+    test.equal(bel.execute('(def defadd (x) (def add (y) (+ x y))) (defadd 2) (add 40)'), 42);
 };
-


### PR DESCRIPTION
`bel.execute` takes a single argument.

Remove unused argument from `execute` calls in `test/execute.js`